### PR TITLE
fix: restore auth binding requirement dropped during SEP-2663 port

### DIFF
--- a/specification/draft/tasks.md
+++ b/specification/draft/tasks.md
@@ -900,6 +900,7 @@ The `tasks/get` endpoint returns exactly what the underlying request would have 
 ## Security Considerations
 
 - **Task ID unguessability.** A server **MAY** use task IDs as bearer tokens for a server's stored state. Servers **MUST** generate them with sufficient entropy that a third party cannot enumerate or guess them.
+- **Auth binding.** Servers **MUST** perform authentication and authorization checks on each task-related request to ensure that the client has permission to access a task.
 - **Cross-caller correlation.** Because there is no `tasks/list`, a server cannot inadvertently leak the existence of one caller's tasks to another. This is an improvement over the `2025-11-25` tasks specification, in which a poorly-scoped list could expose unrelated task IDs.
 - **Input-request trust model.** `inputRequests` carry elicitation and sampling payloads from the server through the client to the user or model. Hosts **MUST** apply the same trust model to these payloads as they would to standard elicitation/sampling requests. A task is not a higher-trust channel.
 


### PR DESCRIPTION
Restores one normative bullet that was dropped when SEP-2663's Security Implications were ported into `specification/draft/tasks.md`.

## Motivation and Context

SEP-2663 Security Implications contains four bullets. The tasks spec's Security Considerations contains only three of them, verbatim, but omits the second bullet point:

  > - **Auth binding.** Servers **MUST** perform authentication and authorization
  >   checks on each task-related request to ensure that the client has permission
  >   to access a task.

The effect of the omission is that `tasks/get`, `tasks/update`, `tasks/cancel` and `taskIds` filters on `subscriptions/listen` currently have no specified authorization requirement. Two of those mutate state: `tasks/get` is specified  as a simple unconditional of 'MUST-return' with no authorization step, and the core `subscriptions/listen` section contains no access-control language to inherit from so as written also requires no authz. As written, an unguessable task ID is the only control the specification mandates.

The `2025-11-25` core spec's tasks section had five normative authorization statements, including "receivers **MUST** bind tasks to said context" and a MUST to reject cross-context requests. This extension supersedes that feature and currently carries no authorization statements. 

I'm raising this as a plain PR rather than a SEP as it restores previously-agreed normative text rather than proposing anything new, which I think falls under the SEP guidelines' "Skip the SEP process for: bug fixes".  I'm happy to open a SEP instead if maintainers think that's a better route.

## How Has This Been Tested?

N/A normative prose only change. No schema change, and no wire format change. No changes to observed behaviour of the protocol.

## Breaking Changes

None

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
 
 None
