### PR TITLE
fix: correct MISSING_REQUIRED_CLIENT_CAPABILITY error code to -32021

### DIFF
--- a/seps/2663-tasks-extension.md
+++ b/seps/2663-tasks-extension.md
@@ -86,7 +86,7 @@ A server that has negotiated this extension **MAY** return `CreateTaskResult` in
 
 A server **MUST NOT** return `CreateTaskResult` to a client that did not include the extension capability on its request, regardless of prior declarations. A client that has negotiated this extension **MUST** be prepared to handle either `CallToolResult` or `CreateTaskResult` in response to any supported request it issues. A client that receives `CreateTaskResult` in response to an unsupported request type **MUST** interpret this as an invalid response to the request.
 
-If a server is unable to service a request to a client that does not declare this extension capability without returning `CreateTaskResult`, the server **MUST** return an error with the code `-32003` (Missing Required Client Capability), indicating the required extension in the error response:
+If a server is unable to service a request to a client that does not declare this extension capability without returning `CreateTaskResult`, the server **MUST** return an error with the code `-32021` (Missing Required Client Capability), indicating the required extension in the error response:
 
 ```jsonl
 {
@@ -94,7 +94,7 @@ If a server is unable to service a request to a client that does not declare thi
   "id": 1,
   "error": {
     // MISSING_REQUIRED_CLIENT_CAPABILITY
-    "code": -32003,
+    "code": -32021,
     // Message provided for example purposes only. The content of this example message is non-normative.
     "message": "Missing required client capability",
     "data": {
@@ -468,7 +468,7 @@ If a client requests task status notifications but does not declare the `io.mode
   "id": 12,
   "error": {
     // MISSING_REQUIRED_CLIENT_CAPABILITY
-    "code": -32003,
+    "code": -32021,
     // Message provided for example purposes only. The content of this example message is non-normative.
     "message": "Missing required client capability",
     "data": {
@@ -798,7 +798,7 @@ Servers **MUST** return standard JSON-RPC errors for the following protocol erro
   - Servers **MUST** return this error for `tasks/get`.
   - Servers **SHOULD** return this error for `tasks/update` and `tasks/cancel`.
 - Internal errors: `-32603` (Internal error)
-- Missing required client capabilities: `-32003` (Missing Required Client Capability)
+- Missing required client capabilities: `-32021` (Missing Required Client Capability)
   - Servers **MUST** return this error for non-declaring clients requesting task notifications on `subscriptions/listen`.
   - Servers **MUST** return this error for non-declaring clients issuing `tasks/get`, `tasks/update`, and `tasks/cancel` requests.
 

--- a/specification/draft/tasks.md
+++ b/specification/draft/tasks.md
@@ -60,7 +60,7 @@ A server that has negotiated this extension **MAY** return `CreateTaskResult` in
 
 A server **MUST NOT** return `CreateTaskResult` to a client that did not include the extension capability on its request, regardless of prior declarations. A client that has negotiated this extension **MUST** be prepared to handle either `CallToolResult` or `CreateTaskResult` in response to any supported request it issues. A client that receives `CreateTaskResult` in response to an unsupported request type **MUST** interpret this as an invalid response to the request.
 
-If a server is unable to service a request to a client that does not declare this extension capability without returning `CreateTaskResult`, the server **MUST** return an error with the code `-32003` (Missing Required Client Capability), indicating the required extension in the error response:
+If a server is unable to service a request to a client that does not declare this extension capability without returning `CreateTaskResult`, the server **MUST** return an error with the code `-32021` (Missing Required Client Capability), indicating the required extension in the error response:
 
 ```jsonl
 {
@@ -68,7 +68,7 @@ If a server is unable to service a request to a client that does not declare thi
   "id": 1,
   "error": {
     // MISSING_REQUIRED_CLIENT_CAPABILITY
-    "code": -32003,
+    "code": -32021,
     // Message provided for example purposes only. The content of this example message is non-normative.
     "message": "Missing required client capability",
     "data": {
@@ -461,7 +461,7 @@ If a client requests task status notifications but does not declare the `io.mode
   "jsonrpc": "2.0",
   "id": 12,
   "error": {
-    "code": -32003,
+    "code": -32021,
     "message": "Missing required client capability",
     "data": {
       "requiredCapabilities": {
@@ -794,7 +794,7 @@ Servers **MUST** return standard JSON-RPC errors for the following protocol erro
   - Servers **MUST** return this error for `tasks/get`.
   - Servers **SHOULD** return this error for `tasks/update` and `tasks/cancel`.
 - Internal errors: `-32603` (Internal error)
-- Missing required client capabilities: `-32003` (Missing Required Client Capability)
+- Missing required client capabilities: `-32021` (Missing Required Client Capability)
   - Servers **MUST** return this error for non-declaring clients requesting task notifications on `subscriptions/listen`.
   - Servers **MUST** return this error for non-declaring clients issuing `tasks/get`, `tasks/update`, and `tasks/cancel` requests.
 


### PR DESCRIPTION
Updates the Missing Required Client Capability error code from `-32003` to `-32021` to match the shipped core specification.

## Motivation and Context

Core renumbered this error code as part of the `2026-07-28` release and corrected its own copy of SEP-2663 in commit 9b44c6b ("fix: correct MISSING_REQUIRED_CLIENT_CAPABILITY error codes in SEP-2663"). The conformance suite followed and now asserts `-32021`.

This repository did not seem to renumber. Both `specification/draft/tasks.md` and its copy of SEP-2663 still specify `-32003` throughout their text.

The practical effect is that the conformance suite currently tests for an error code the extension's normative text does not define. A server author who implements this specification literally will emit `-32003` for a non-declaring client and fail conformance, with the spec on their side and the test suite against them.


## How Has This Been Tested?
 NA. The change is to error code literals in normative prose + JSON examples. No schema changes. The resulting code matches what the conformance suite already asserts.

## Breaking Changes

None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context

None
