### PR TITLE
Fix Missing Required Client Capability error code

### DIFF
--- a/specification/draft/tasks.md
+++ b/specification/draft/tasks.md
@@ -60,7 +60,7 @@ A server that has negotiated this extension **MAY** return `CreateTaskResult` in
 
 A server **MUST NOT** return `CreateTaskResult` to a client that did not include the extension capability on its request, regardless of prior declarations. A client that has negotiated this extension **MUST** be prepared to handle either `CallToolResult` or `CreateTaskResult` in response to any supported request it issues. A client that receives `CreateTaskResult` in response to an unsupported request type **MUST** interpret this as an invalid response to the request.
 
-If a server is unable to service a request to a client that does not declare this extension capability without returning `CreateTaskResult`, the server **MUST** return an error with the code `-32003` (Missing Required Client Capability), indicating the required extension in the error response:
+If a server is unable to service a request to a client that does not declare this extension capability without returning `CreateTaskResult`, the server **MUST** return an error with the code `-32021` (Missing Required Client Capability), indicating the required extension in the error response:
 
 ```jsonl
 {
@@ -68,7 +68,7 @@ If a server is unable to service a request to a client that does not declare thi
   "id": 1,
   "error": {
     // MISSING_REQUIRED_CLIENT_CAPABILITY
-    "code": -32003,
+    "code": -32021,
     // Message provided for example purposes only. The content of this example message is non-normative.
     "message": "Missing required client capability",
     "data": {
@@ -461,7 +461,7 @@ If a client requests task status notifications but does not declare the `io.mode
   "jsonrpc": "2.0",
   "id": 12,
   "error": {
-    "code": -32003,
+    "code": -32021,
     "message": "Missing required client capability",
     "data": {
       "requiredCapabilities": {
@@ -794,7 +794,7 @@ Servers **MUST** return standard JSON-RPC errors for the following protocol erro
   - Servers **MUST** return this error for `tasks/get`.
   - Servers **SHOULD** return this error for `tasks/update` and `tasks/cancel`.
 - Internal errors: `-32603` (Internal error)
-- Missing required client capabilities: `-32003` (Missing Required Client Capability)
+- Missing required client capabilities: `-32021` (Missing Required Client Capability)
   - Servers **MUST** return this error for non-declaring clients requesting task notifications on `subscriptions/listen`.
   - Servers **MUST** return this error for non-declaring clients issuing `tasks/get`, `tasks/update`, and `tasks/cancel` requests.
 


### PR DESCRIPTION
The spec cites `-32003` for "Missing Required Client Capability". The canonical code is `-32021`.

Evidence:

| Source | Value |
|---|---|
| [SEP-2663](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/seps/2663-tasks-extension.md) | `-32021`, in all four of these same spots |
| Core `2026-07-28` schema, `MissingRequiredClientCapabilityError` | `-32021` |
| Core `draft` schema | `-32021` |
| TypeScript SDK, `MISSING_REQUIRED_CLIENT_CAPABILITY` | `-32021` |

`-32003` appears in no core schema version (`2025-06-18`, `2025-11-25`, `2026-07-28`, `draft`).

It looks like this came in with the SEP-2663 port in 29f83d5 — the added lines already read `-32003`, whereas SEP-2663 says `-32021`. Supporting this, one of the affected examples carries the comment `// MISSING_REQUIRED_CLIENT_CAPABILITY` immediately above the value, and that constant is exactly `-32021` in the TypeScript SDK.

Docs-only: error codes aren't encoded in `schema.ts` or the generated `schema.json`, so no regeneration is needed.

I noticed this while implementing the tasks extension capability negotiation in the Go SDK ([modelcontextprotocol/go-sdk#755](https://github.com/modelcontextprotocol/go-sdk/pull/755)), which already implements this error as `-32021`.

CONTRIBUTING notes that changes should go through the Agents Working Group first. I've opened this directly since it's a factual correction rather than a design change — happy to take it to the WG instead if you'd prefer.
